### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,9 @@ jobs:
           tag: ci-semi-stable
 
       - name: Setup typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.12.0'
+          typst-version: 'v0.12.0'
 
       - name: Run test suite
         run: typst-test run


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.

> [!WARNING]
>  I have not verified if other PRs have made the same changes. If you have spare time, please merge previous PRs before working on this one to avoid git conflicts.